### PR TITLE
docs: fix perf issue in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,37 +43,38 @@ Picostyle React works well with:
 
 ```js
 import React from "react"
-import ReactDOM from 'react-dom'
+import ReactDOM from "react-dom"
 import picostyle from "picostyle-react"
 
 const ps = picostyle(React.createElement)
 
+const keyColor = "#f07"
+
+const Text = ps("h1")({
+  fontSize: "64px",
+  cursor: "pointer",
+  color: "#fff",
+  padding: "0.4em",
+  transition: "all .2s ease-in-out",
+  ":hover": {
+    transform: "scale(1.3)",
+  },
+  "@media (max-width: 450px)": {
+    fontSize: "32px",
+  },
+})
+
+const Wrapper = ps("div")({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  width: "100vw",
+  height: "100vh",
+  backgroundColor: keyColor,
+})
+
 class Hello extends React.Component {
   render() {
-    const keyColor = "#f07"
-
-    const Text = ps("h1")({
-      fontSize: "64px",
-      cursor: "pointer",
-      color: "#fff",
-      padding: "0.4em",
-      transition: "all .2s ease-in-out",
-      ":hover": {
-        transform: "scale(1.3)",
-      },
-      "@media (max-width: 450px)": {
-        fontSize: "32px",
-      },
-    })
-
-    const Wrapper = ps("div")({
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-      width: "100vw",
-      height: "100vh",
-      backgroundColor: keyColor,
-    })
 
     return (
       <Wrapper id="pico">


### PR DESCRIPTION
Creating and rendering components in render forces those components (and their children) to unmount and remount ever render which is pretty bad for performance.

This updates the example to put those definitions at the root.